### PR TITLE
Add conditional expression to avoid concurrent update

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -212,6 +212,7 @@ Resources:
             - Effect: Allow
               Action:
                 - 'dynamodb:DeleteItem'
+                - 'dynamodb:GetItem'
                 - 'dynamodb:PutItem'
                 - 'dynamodb:UpdateItem'
               Resource:


### PR DESCRIPTION
During higher loads, multiple Lambdas may be trying to update the successes or failures concurrently. If we're unlucky, additions may be lost. To make sure every one is counted, add a conditional expression and a simple while loop.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
